### PR TITLE
Fix concurrent map access

### DIFF
--- a/joysticks.go
+++ b/joysticks.go
@@ -429,7 +429,7 @@ func (d HID) HatExists(index uint8) (ok bool) {
 func (d HID) ButtonClosed(index uint8) bool {
 	d.hatLock.RLock()
 	val := d.Buttons[index].value
-	d.hatLock.Unlock()
+	d.hatLock.RUnlock()
 	return val
 }
 

--- a/joysticks_linux.go
+++ b/joysticks_linux.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 )
 
@@ -38,7 +39,7 @@ func Connect(index int) (d *HID) {
 	if e != nil {
 		return nil
 	}
-	d = &HID{make(chan osEventRecord), make(map[uint8]button), make(map[uint8]hatAxis), make(map[eventSignature]chan Event)}
+	d = &HID{make(chan osEventRecord), make(map[uint8]button), make(map[uint8]hatAxis), make(map[eventSignature]chan Event), &sync.RWMutex{},&sync.RWMutex{}, &sync.RWMutex{}}
 	// start thread to read joystick events to the joystick.state osEvent channel
 	go eventPipe(r, d.OSEvents)
 	d.populate()


### PR DESCRIPTION
Fixes fatal panic error for `concurrent map iteration and map write` on buttons, events and hats maps using RWLocks.

